### PR TITLE
[cmyk-116] Schema 이름 변경

### DIFF
--- a/src/main/java/com/cmyk/ego/speaktoyouspring/config/FlywayConfig.java
+++ b/src/main/java/com/cmyk/ego/speaktoyouspring/config/FlywayConfig.java
@@ -2,7 +2,7 @@ package com.cmyk.ego.speaktoyouspring.config;
 
 import com.cmyk.ego.speaktoyouspring.api.hub.tenant.TenantService;
 import com.cmyk.ego.speaktoyouspring.config.properties.HubProperties;
-import com.cmyk.ego.speaktoyouspring.config.properties.TenantProperties;
+import com.cmyk.ego.speaktoyouspring.config.properties.PersonalizedDataProperties;
 import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
 import org.flywaydb.core.Flyway;
@@ -17,16 +17,16 @@ import java.util.Set;
 @EnableConfigurationProperties(FlywayProperties.class)
 @RequiredArgsConstructor
 public class FlywayConfig {
-    private final TenantProperties tenantProperties;
+    private final PersonalizedDataProperties personalizedDataProperties;
     private final HubProperties hubProperties;
     private final FlywayProperties flywayProperties;
 
     private final TenantService tenantService;
 
-    /// metadata와 tenant Database를 마이그레이션(형상 관리) 하는 함수.
+    /// hub와 personalized-data Database를 마이그레이션(형상 관리) 하는 함수.
     @PostConstruct
     public void migrateFlyway() {
-        // metadata Database에 관한 정보를 명시한다.
+        // hub Database에 관한 정보를 명시한다.
         Flyway.configure()
                 .dataSource(hubProperties.getDatasource())
                 .locations(flywayProperties.getLocations().getFirst()) // application.yml에서 경로 로드
@@ -35,13 +35,13 @@ public class FlywayConfig {
                 .migrate();
 
         // 모든 스키마 정보(스키마 이름)를 얻는다.
-        // 현재 tenant Database의 개별 스키마는 metadata.tenant.schemaName으로 등록되기 때문이다.
+        // 현재 personalized-data Database의 개별 스키마는 hub.tenant.schemaName으로 등록되기 때문이다.
         final Set<String> schemas = tenantService.getTenantName();
 
-        // tenant Database에 관한 정보를 명시한다.
+        // personalized-data Database에 관한 정보를 명시한다.
         schemas.forEach(schema -> {
             Flyway.configure()
-                    .dataSource(tenantProperties.getDataSource())
+                    .dataSource(personalizedDataProperties.getDataSource())
                     .locations(flywayProperties.getLocations().get(1))
                     .baselineOnMigrate(flywayProperties.isBaselineOnMigrate()) // 기존 DB를 기준점으로 설정할지 여부
                     .defaultSchema(schema) // 개별 테넌트 스키마 이름 적용

--- a/src/main/java/com/cmyk/ego/speaktoyouspring/config/TenantConfig.java
+++ b/src/main/java/com/cmyk/ego/speaktoyouspring/config/TenantConfig.java
@@ -1,6 +1,6 @@
 package com.cmyk.ego.speaktoyouspring.config;
 
-import com.cmyk.ego.speaktoyouspring.config.properties.TenantProperties;
+import com.cmyk.ego.speaktoyouspring.config.properties.PersonalizedDataProperties;
 import com.cmyk.ego.speaktoyouspring.util.querydsl.QuerydslJpaRepositoryFactoryBean;
 import jakarta.persistence.EntityManagerFactory;
 import lombok.RequiredArgsConstructor;
@@ -36,17 +36,17 @@ public class TenantConfig {
     // 파일 내에서만 url을 사용 가능하도록 Default 접근 지정자 설정
     static final String BASE_PACKAGE = "com.cmyk.ego.speaktoyouspring.api.tenant";
     private final JpaProperties jpaProperties; // TODO: ???
-    private final TenantProperties tenantProperties;
+    private final PersonalizedDataProperties personalizedDataProperties;
 
     @Bean
     JpaVendorAdapter jpaVendorAdapter() {
         return new HibernateJpaVendorAdapter();
     }
 
-    /// tenant 데이터베이스에 대한 데이터 소스를 저장한다.
+    /// personalized-data 데이터베이스에 대한 데이터 소스를 저장한다.
     @Bean
-    public DataSource tenantDataSource() {
-        return tenantProperties.getDataSource();
+    public DataSource personalizedDataSource() {
+        return personalizedDataProperties.getDataSource();
     }
 
     /// 엔티티를 조작할 Manager를 생성
@@ -68,7 +68,7 @@ public class TenantConfig {
 
         // LocalContainerEntityManagerFactoryBean 설정
         LocalContainerEntityManagerFactoryBean em = new LocalContainerEntityManagerFactoryBean();
-        em.setDataSource(tenantDataSource()); // 멀티 테넌트 데이터 소스 설정
+        em.setDataSource(personalizedDataSource()); // personalized-data의 데이터 소스 설정
         em.setPackagesToScan(BASE_PACKAGE); // 엔티티 클래스가 포함된 패키지를 스캔
         em.setJpaVendorAdapter(jpaVendorAdapter()); // JPA 구현체 설정 (Hibernate)
         em.setJpaPropertyMap(jpaPropertiesMap); // JPA 속성 설정

--- a/src/main/java/com/cmyk/ego/speaktoyouspring/config/flyway/FlywayService.java
+++ b/src/main/java/com/cmyk/ego/speaktoyouspring/config/flyway/FlywayService.java
@@ -2,7 +2,7 @@ package com.cmyk.ego.speaktoyouspring.config.flyway;
 
 import com.cmyk.ego.speaktoyouspring.api.hub.tenant.Tenant;
 import com.cmyk.ego.speaktoyouspring.api.hub.tenant.TenantService;
-import com.cmyk.ego.speaktoyouspring.config.properties.TenantProperties;
+import com.cmyk.ego.speaktoyouspring.config.properties.PersonalizedDataProperties;
 import lombok.RequiredArgsConstructor;
 import org.flywaydb.core.Flyway;
 import org.springframework.boot.autoconfigure.flyway.FlywayProperties;
@@ -14,16 +14,16 @@ import org.springframework.stereotype.Service;
 @EnableConfigurationProperties(FlywayProperties.class)
 @RequiredArgsConstructor
 public class FlywayService {
-    private final TenantProperties tenantProperties;
+    private final PersonalizedDataProperties personalizedDataProperties;
     private final FlywayProperties flywayProperties;
 
     private final TenantService tenantService;
 
-    /// tenant Database에 새로운 schema를 생성하는 함수
+    /// personalized-data Database에 새로운 schema를 생성하는 함수
     /// @param tenantName 새로 생성할 schema 이름
     public Tenant createTenant(String tenantName) {
         Flyway.configure()
-                .dataSource(tenantProperties.getDataSource())
+                .dataSource(personalizedDataProperties.getDataSource())
                 .locations(flywayProperties.getLocations().get(1)) // application.yml에서 경로 로드
                 .baselineOnMigrate(flywayProperties.isBaselineOnMigrate()) // 기존 DB를 기준점으로 설정할지 여부
                 .schemas(tenantName)
@@ -35,7 +35,7 @@ public class FlywayService {
             .tenantName(tenantName)
             .build();
 
-        tenantService.create(tenant);  // metadata.tenant 테이블에 테넌트 정보 저장
+        tenantService.create(tenant);  // hub.tenant 테이블에 테넌트 정보 저장
         return tenant;
     }
 
@@ -43,7 +43,7 @@ public class FlywayService {
     /// TODO: 권한 등의 대책을 마련할 필요가 있다.
     public Tenant deleteTenant(String tenantName) {
         Flyway.configure()
-                .dataSource(tenantProperties.getDataSource())
+                .dataSource(personalizedDataProperties.getDataSource())
                 .locations(flywayProperties.getLocations().get(1))
                 .baselineOnMigrate(flywayProperties.isBaselineOnMigrate())
                 .cleanDisabled(false)

--- a/src/main/java/com/cmyk/ego/speaktoyouspring/config/multitenancy/TenantConnectionProvider.java
+++ b/src/main/java/com/cmyk/ego/speaktoyouspring/config/multitenancy/TenantConnectionProvider.java
@@ -16,8 +16,8 @@ import java.sql.SQLException;
 public class TenantConnectionProvider implements MultiTenantConnectionProvider {
     private final DataSource dataSource;
 
-    /// DataSource를 불러오는 함수
-    public TenantConnectionProvider(@Qualifier("tenantDataSource") DataSource dataSource) {
+    /// personalized-data의 DataSource를 불러오는 함수
+    public TenantConnectionProvider(@Qualifier("personalizedDataSource") DataSource dataSource) {
         this.dataSource = dataSource;
     }
 

--- a/src/main/java/com/cmyk/ego/speaktoyouspring/config/properties/PersonalizedDataProperties.java
+++ b/src/main/java/com/cmyk/ego/speaktoyouspring/config/properties/PersonalizedDataProperties.java
@@ -8,8 +8,8 @@ import javax.sql.DataSource;
 
 /// `apllication.yml`에 있는 정보를 가져오는 Propertie 클래스이다.
 @Data
-@ConfigurationProperties(prefix = "tenant.datasource")
-public class TenantProperties {
+@ConfigurationProperties(prefix = "personalized-data.datasource")
+public class PersonalizedDataProperties {
     private String jdbcUrl; // 데이터베이스 경로
     private String username; // 사용자 이름
     private String password; // 비밀번호


### PR DESCRIPTION
### JIRA Task 🔖
**Ticket**: [CMYK-116](https://hansung-capstone-cmyk.atlassian.net/browse/CMYK-116)
- **Branch** : feat/CMYK-116

### 작업 내용 📌
- tenant Database의 이름을 personalized-data로 변경합니다.
- Database의 이름이 변경됨에 따라 application.yml도 변경했습니다. [.yml](https://hansung-capstone-cmyk.atlassian.net/wiki/spaces/~7120209bd9ff0e93064b889ae9b0e70ada9c42/pages/27623460/Speak-to-you+Spring)
 
### 참고 사항 📂
- 현재 [confluence](https://hansung-capstone-cmyk.atlassian.net/wiki/spaces/~7120209bd9ff0e93064b889ae9b0e70ada9c42/pages/34734095/DB)에 작성해 둔것처럼 hub의 tenant table이름과 구성을 변경해야 하지만 해당 부분이
[JIRA-156](https://hansung-capstone-cmyk.atlassian.net/browse/CMYK-156)와 겹쳐서 해당 이슈에서 같이 처리하도록 하겠습니다.


[CMYK-116]: https://hansung-capstone-cmyk.atlassian.net/browse/CMYK-116?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ