### PR TITLE
[CMYK-184] 에고 성격 관리 API

### DIFF
--- a/src/main/java/com/cmyk/ego/speaktoyouspring/api/flyway/FlywayController.java
+++ b/src/main/java/com/cmyk/ego/speaktoyouspring/api/flyway/FlywayController.java
@@ -26,7 +26,7 @@ public class FlywayController {
 
     private final UserAccountService userAccountService;
 
-    @PostMapping("/")
+    @PostMapping("")
     public ResponseEntity migrateFlyway() {
         // hub Database에 관한 정보를 명시한다.
         Flyway.configure()

--- a/src/main/java/com/cmyk/ego/speaktoyouspring/api/hub/ego/Ego.java
+++ b/src/main/java/com/cmyk/ego/speaktoyouspring/api/hub/ego/Ego.java
@@ -37,10 +37,6 @@ public class Ego {
     @Column(name = "mbti", length = 4)
     private String mbti;
 
-    /// EGO 성격 설명
-    @Column(name = "personality", length = 255)
-    private String personality;
-
     /// EGO 생성 날짜
     @Builder.Default
     @Column(name = "created_at")

--- a/src/main/java/com/cmyk/ego/speaktoyouspring/api/hub/ego/Ego.java
+++ b/src/main/java/com/cmyk/ego/speaktoyouspring/api/hub/ego/Ego.java
@@ -29,8 +29,7 @@ public class Ego {
     private String introduction;
 
     /// EGO 프로필 이미지 (Byte 데이터)
-    @Lob
-    @Column(name = "profile_image")
+    @Column(name = "profile_image", columnDefinition = "BYTEA")
     private byte[] profileImage;
 
     /// EGO MBTI 성격 유형

--- a/src/main/java/com/cmyk/ego/speaktoyouspring/api/hub/ego/EgoApplicationService.java
+++ b/src/main/java/com/cmyk/ego/speaktoyouspring/api/hub/ego/EgoApplicationService.java
@@ -1,5 +1,9 @@
 package com.cmyk.ego.speaktoyouspring.api.hub.ego;
 
+import com.cmyk.ego.speaktoyouspring.api.hub.ego_personality.EgoPersonality;
+import com.cmyk.ego.speaktoyouspring.api.hub.ego_personality.EgoPersonalityService;
+import com.cmyk.ego.speaktoyouspring.api.hub.personality.Personality;
+import com.cmyk.ego.speaktoyouspring.api.hub.personality.PersonalityService;
 import com.cmyk.ego.speaktoyouspring.api.hub.user_account.UserAccountRepository;
 import com.cmyk.ego.speaktoyouspring.api.personalized_data.chatroom.ChatRoom;
 import com.cmyk.ego.speaktoyouspring.api.personalized_data.chatroom.ChatRoomService;
@@ -11,6 +15,7 @@ import com.cmyk.ego.speaktoyouspring.exception.errorcode.UserAccountErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @Service
@@ -19,6 +24,8 @@ public class EgoApplicationService {
     private final EgoService egoService;
     private final ChatRoomService chatRoomService;
     private final EvaluationService evaluationService;
+    private final EgoPersonalityService egoPersonalityService;
+    private final PersonalityService personalityService;
     private final UserAccountRepository userAccountRepository;
 
     public List<Ego> getUserEgoList(String userId) {
@@ -34,5 +41,52 @@ public class EgoApplicationService {
         List<Evaluation> userEvaluationList = evaluationService.readAll();
 
         return egoService.joinEgoList(egoList, userEgoList, userEvaluationList);
+    }
+
+    /// personality 배열을 테이블에 저장
+    public void savePersonality(Long egoId, List<String> personalityList) {
+        egoPersonalityService.deleteAllByEgoId(egoId);
+
+        for (String personality : personalityList) {
+            Personality personalityEntity = personalityService.add(personality);
+            if (personalityEntity != null) {
+                egoPersonalityService.add(egoId, personalityEntity.getPersonalityId());
+            }
+        }
+
+    }
+
+    // ego_id로 에고 정보와 성격 정보 조회
+    public EgoDTO getEgoInfo(Long egoId) {
+        // 에고 기본 정보 조회
+        Ego ego = egoService.findById(egoId);
+
+        // 에고 성격 리스트 조회
+        List<EgoPersonality> personalityList = egoPersonalityService.findByEgoId(egoId);
+        List<String> personalityNameList = new ArrayList<>();
+        for (EgoPersonality personality : personalityList) {
+            personalityNameList.add(personalityService.findByPersonalityId(personality.getPersonalityId()).getContent());
+        }
+
+        // 에고 성격 리스트 에고 정보에 추가
+        EgoDTO egoDTO = convertEgoDTO(ego);
+        egoDTO.setPersonalityList(personalityNameList);
+        return egoDTO;
+    }
+
+    public EgoDTO convertEgoDTO(Ego ego) {
+        return new EgoDTO(ego.getId(), ego.getName(), ego.getIntroduction(), ego.getProfileImage(), ego.getMbti(), ego.getCreatedAt(), ego.getLikes(), new ArrayList<>());
+    }
+
+    /// ego_id로 ego 정보 및 personality 정보 갱신
+    public EgoDTO updateEgoInfo(EgoDTO egoDTO) {
+        Ego ego = egoService.update(egoDTO);
+
+        savePersonality(ego.getId(), egoDTO.getPersonalityList());
+
+        // 에고 성격 리스트 에고 정보에 추가
+        EgoDTO convertedEgoDTO = convertEgoDTO(ego);
+        convertedEgoDTO.setPersonalityList(egoDTO.getPersonalityList());
+        return convertedEgoDTO;
     }
 }

--- a/src/main/java/com/cmyk/ego/speaktoyouspring/api/hub/ego/EgoController.java
+++ b/src/main/java/com/cmyk/ego/speaktoyouspring/api/hub/ego/EgoController.java
@@ -1,6 +1,7 @@
 package com.cmyk.ego.speaktoyouspring.api.hub.ego;
 
 import com.cmyk.ego.speaktoyouspring.config.CommonResponse;
+import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -22,6 +23,7 @@ public class EgoController {
     /**
      * ego 생성
      * */
+    @Operation(summary = "ego 생성", description = "ego정보를 생성한다.")
     @PostMapping
     public ResponseEntity create(@RequestBody @Valid EgoDTO egoDTO, BindingResult bindingResult) {
 
@@ -35,7 +37,8 @@ public class EgoController {
                     .build());
         }
 
-        var result = egoService.create(egoDTO);
+        Ego result = egoService.create(egoDTO);
+        egoApplicationService.savePersonality(result.getId(), egoDTO.getPersonalityList());
 
         return ResponseEntity.ok(CommonResponse.builder().code(200).message("ego 생성 완료").data(result).build());
     }
@@ -43,6 +46,7 @@ public class EgoController {
     /**
      * ego테이블에 기록된 전체 ego조회
      */
+    @Operation(summary = "전체 ego 조회", description = "전체 ego정보를 조회한다.")
     @GetMapping
     public ResponseEntity readAll() {
 
@@ -54,10 +58,11 @@ public class EgoController {
     /**
      * egoid와 일치하는 ego조회
      * */
+    @Operation(summary = "ego 정보 조회", description = "egoId를 기준으로 ego정보를 조회한다.")
     @GetMapping("/{egoid}")
     public ResponseEntity read(@PathVariable("egoid") Long egoId) {
 
-        var result = egoService.findById(egoId);
+        var result = egoApplicationService.getEgoInfo(egoId);
 
         return ResponseEntity.ok(CommonResponse.builder().code(200).message("ego 조회 완료").data(result).build());
     }
@@ -65,17 +70,18 @@ public class EgoController {
     /**
      * ego정보 수정
      * */
+    @Operation(summary = "ego 정보 수정", description = "egoId를 기준으로 ego정보를 수정한다.")
     @PatchMapping
     public ResponseEntity update(@RequestBody EgoDTO egoDTO) {
 
         if (egoDTO.getId() == null) {
-            ResponseEntity.badRequest().body(CommonResponse.builder()
+            return ResponseEntity.badRequest().body(CommonResponse.builder()
                     .code(400)
-                    .message("egoId는 필수 값입니다.")
+                    .message("id는 EGO 테이블의 id 값으로 업데이트시 필수 값입니다. (예: \"id\": 8)")
                     .build());
         }
 
-        var result = egoService.update(egoDTO);
+        var result = egoApplicationService.updateEgoInfo(egoDTO);
 
         return ResponseEntity.ok(CommonResponse.builder().code(200).message("ego 수정 완료").data(result).build());
     }
@@ -83,6 +89,7 @@ public class EgoController {
     /**
      * EGO 정보 불러오기
      */
+    @Operation(summary = "ego 정보 불러오기", description = "userId를 기준으로 ego정보를 불러온다.")
     @GetMapping("/{userid}/list")
     public ResponseEntity getUserEgoList(@PathVariable("userid") String userId) {
 

--- a/src/main/java/com/cmyk/ego/speaktoyouspring/api/hub/ego/EgoDTO.java
+++ b/src/main/java/com/cmyk/ego/speaktoyouspring/api/hub/ego/EgoDTO.java
@@ -8,6 +8,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDate;
+import java.util.List;
 
 @Getter
 @Builder
@@ -36,6 +37,8 @@ public class EgoDTO {
 
     private Long likes;
 
+    private List<String> personalityList;
+
     public Ego toEntity() {
         return Ego.builder()
                 .id(id)
@@ -43,7 +46,6 @@ public class EgoDTO {
                 .introduction(introduction)
                 .profileImage(profileImage)
                 .mbti(mbti)
-                .personality(personality)
                 .createdAt(createdAt)
                 .likes(likes)
                 .build();

--- a/src/main/java/com/cmyk/ego/speaktoyouspring/api/hub/ego/EgoDTO.java
+++ b/src/main/java/com/cmyk/ego/speaktoyouspring/api/hub/ego/EgoDTO.java
@@ -1,42 +1,45 @@
 package com.cmyk.ego.speaktoyouspring.api.hub.ego;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import java.time.LocalDate;
 import java.util.List;
 
 @Getter
+@Setter
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
 public class EgoDTO {
 
+    @Schema(hidden = true)
     private Long id;                      // EGO 고유 ID
 
+    @Schema(example = "카리나")
     @NotBlank(message = "name은 필수입니다.")
     private String name;                     // EGO 이름
 
     @NotBlank(message = "introduction은 필수입니다.")
     private String introduction;             // EGO 자기소개
 
+    @Schema(example = "iVBORw0KGgoAAAANSUhEUgAAAAUAAAAFCAYAAACN")
     private byte[] profileImage;             // EGO 프로필 이미지
 
+    @Schema(example = "INTJ")
     @NotBlank(message = "mbti는 필수입니다.")
     private String mbti;                     // MBTI 성격 유형
 
-    @NotBlank(message = "personality는 필수입니다.")
-    private String personality;              // EGO 성격 설명
-
+    @Schema(example = "2025-05-06")
     @JsonFormat(pattern = "yyyy-MM-dd")
     private LocalDate createdAt;             // 생성 날짜
 
+    @Schema(example = "1000")
     private Long likes;
 
+    @Schema(example = "[\"늘정주나\", \"시간마술사\", \"존댓말자동완성\", \"식사개근\", \"유교휴먼\", \"TMI장인\", \"콘센트헌터\"]")
     private List<String> personalityList;
 
     public Ego toEntity() {

--- a/src/main/java/com/cmyk/ego/speaktoyouspring/api/hub/ego/EgoService.java
+++ b/src/main/java/com/cmyk/ego/speaktoyouspring/api/hub/ego/EgoService.java
@@ -58,8 +58,8 @@ public class EgoService {
             ego.setProfileImage(egoDTO.getProfileImage());
         if (egoDTO.getMbti() != null)
             ego.setMbti(egoDTO.getMbti());
-        if (egoDTO.getPersonality() != null)
-            ego.setPersonality(egoDTO.getPersonality());
+        // if (egoDTO.getPersonality() != null)
+        // ego.setPersonality(egoDTO.getPersonality());
         if (egoDTO.getCreatedAt() != null)
             ego.setCreatedAt(egoDTO.getCreatedAt());
 

--- a/src/main/java/com/cmyk/ego/speaktoyouspring/api/hub/ego/EgoService.java
+++ b/src/main/java/com/cmyk/ego/speaktoyouspring/api/hub/ego/EgoService.java
@@ -58,8 +58,8 @@ public class EgoService {
             ego.setProfileImage(egoDTO.getProfileImage());
         if (egoDTO.getMbti() != null)
             ego.setMbti(egoDTO.getMbti());
-        // if (egoDTO.getPersonality() != null)
-        // ego.setPersonality(egoDTO.getPersonality());
+        if (egoDTO.getLikes() != null)
+            ego.setLikes(egoDTO.getLikes());
         if (egoDTO.getCreatedAt() != null)
             ego.setCreatedAt(egoDTO.getCreatedAt());
 

--- a/src/main/java/com/cmyk/ego/speaktoyouspring/api/hub/ego_personality/EgoPersonality.java
+++ b/src/main/java/com/cmyk/ego/speaktoyouspring/api/hub/ego_personality/EgoPersonality.java
@@ -1,0 +1,24 @@
+package com.cmyk.ego.speaktoyouspring.api.hub.ego_personality;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "ego_personality") // 테이블 이름
+@Builder
+@Getter
+@Setter
+@RequiredArgsConstructor
+@AllArgsConstructor
+public class EgoPersonality {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY) // 자동 증가
+    @Column(name = "ego_personality_id", nullable = false, unique = true)
+    private Long egoPersonalityId;
+
+    @Column(name = "ego_id", nullable = false)
+    private Long egoId;
+
+    @Column(name = "personality_id", nullable = false)
+    private Long personalityId;
+}

--- a/src/main/java/com/cmyk/ego/speaktoyouspring/api/hub/ego_personality/EgoPersonalityRepository.java
+++ b/src/main/java/com/cmyk/ego/speaktoyouspring/api/hub/ego_personality/EgoPersonalityRepository.java
@@ -1,4 +1,14 @@
 package com.cmyk.ego.speaktoyouspring.api.hub.ego_personality;
 
-public class EgoPersonalityRepository {
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface EgoPersonalityRepository extends JpaRepository<EgoPersonality, Long> {
+    List<EgoPersonality> findByEgoId(Long egoId);
+
+    Optional<EgoPersonality> findByEgoIdAndPersonalityId(Long egoId, Long personalityId);
+
+    void deleteAllByEgoId(Long egoId);
 }

--- a/src/main/java/com/cmyk/ego/speaktoyouspring/api/hub/ego_personality/EgoPersonalityRepository.java
+++ b/src/main/java/com/cmyk/ego/speaktoyouspring/api/hub/ego_personality/EgoPersonalityRepository.java
@@ -1,0 +1,4 @@
+package com.cmyk.ego.speaktoyouspring.api.hub.ego_personality;
+
+public class EgoPersonalityRepository {
+}

--- a/src/main/java/com/cmyk/ego/speaktoyouspring/api/hub/ego_personality/EgoPersonalityService.java
+++ b/src/main/java/com/cmyk/ego/speaktoyouspring/api/hub/ego_personality/EgoPersonalityService.java
@@ -1,4 +1,30 @@
 package com.cmyk.ego.speaktoyouspring.api.hub.ego_personality;
 
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
 public class EgoPersonalityService {
+    private final EgoPersonalityRepository egoPersonalityRepository;
+
+    /// ego_id로 에고 성격 리스트 조회
+    public List<EgoPersonality> findByEgoId(Long egoId) {
+        return egoPersonalityRepository.findByEgoId(egoId);
+    }
+
+    /// ego_id와 personality_id로 에고 성격 추가
+    public EgoPersonality add(Long egoId, Long personalityId) {
+        return egoPersonalityRepository.findByEgoIdAndPersonalityId(egoId, personalityId)
+                .orElseGet(() -> egoPersonalityRepository.save(new EgoPersonality(null, egoId, personalityId)));
+    }
+
+    /// ego_id로 에고 성격 리스트 전체 삭제
+    public void deleteAllByEgoId(Long egoId) {
+        egoPersonalityRepository.deleteAllByEgoId(egoId);
+    }
 }

--- a/src/main/java/com/cmyk/ego/speaktoyouspring/api/hub/ego_personality/EgoPersonalityService.java
+++ b/src/main/java/com/cmyk/ego/speaktoyouspring/api/hub/ego_personality/EgoPersonalityService.java
@@ -1,0 +1,4 @@
+package com.cmyk.ego.speaktoyouspring.api.hub.ego_personality;
+
+public class EgoPersonalityService {
+}

--- a/src/main/java/com/cmyk/ego/speaktoyouspring/api/hub/personality/ContentListRequest.java
+++ b/src/main/java/com/cmyk/ego/speaktoyouspring/api/hub/personality/ContentListRequest.java
@@ -1,0 +1,16 @@
+package com.cmyk.ego.speaktoyouspring.api.hub.personality;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class ContentListRequest {
+    @Schema(example = "[\"늘정주나\", \"시간마술사\", \"존댓말자동완성\", \"식사개근\", \"유교휴먼\", \"TMI장인\", \"콘센트헌터\"]")
+    private List<String> contentList;
+}

--- a/src/main/java/com/cmyk/ego/speaktoyouspring/api/hub/personality/ContentListRequest.java
+++ b/src/main/java/com/cmyk/ego/speaktoyouspring/api/hub/personality/ContentListRequest.java
@@ -11,6 +11,6 @@ import java.util.List;
 @NoArgsConstructor
 @AllArgsConstructor
 public class ContentListRequest {
-    @Schema(example = "[\"늘정주나\", \"시간마술사\", \"존댓말자동완성\", \"식사개근\", \"유교휴먼\", \"TMI장인\", \"콘센트헌터\"]")
-    private List<String> contentList;
+    @Schema(example = "[{\"content\":\"늘정주나\", \"imageUrl\": \"assets/image/game_chat_room.png\"}, {\"content\":\"시간마술사\", \"imageUrl\": \"assets/image/movie_chat_room.png\"}, {\"content\":\"존댓말자동완성\", \"imageUrl\": \"assets/image/music_chat_room.png\"}, {\"content\":\"유교휴먼\", \"imageUrl\": \"assets/image/anime_chat_room.png\"}]")
+    private List<ContentRequest> contentList;
 }

--- a/src/main/java/com/cmyk/ego/speaktoyouspring/api/hub/personality/ContentRequest.java
+++ b/src/main/java/com/cmyk/ego/speaktoyouspring/api/hub/personality/ContentRequest.java
@@ -11,4 +11,7 @@ import lombok.NoArgsConstructor;
 public class ContentRequest {
     @Schema(example = "늘정주나")
     private String content;
+
+    @Schema(example = "assets/image/game_chat_room.png")
+    private String imageUrl;
 }

--- a/src/main/java/com/cmyk/ego/speaktoyouspring/api/hub/personality/ContentRequest.java
+++ b/src/main/java/com/cmyk/ego/speaktoyouspring/api/hub/personality/ContentRequest.java
@@ -1,0 +1,14 @@
+package com.cmyk.ego.speaktoyouspring.api.hub.personality;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class ContentRequest {
+    @Schema(example = "늘정주나")
+    private String content;
+}

--- a/src/main/java/com/cmyk/ego/speaktoyouspring/api/hub/personality/Personality.java
+++ b/src/main/java/com/cmyk/ego/speaktoyouspring/api/hub/personality/Personality.java
@@ -18,4 +18,7 @@ public class Personality {
 
     @Column(name = "content", nullable = false, unique = true)
     private String content;
+
+    @Column(name = "image_url")
+    private String imageUrl;
 }

--- a/src/main/java/com/cmyk/ego/speaktoyouspring/api/hub/personality/Personality.java
+++ b/src/main/java/com/cmyk/ego/speaktoyouspring/api/hub/personality/Personality.java
@@ -1,0 +1,21 @@
+package com.cmyk.ego.speaktoyouspring.api.hub.personality;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "personality") // 테이블 이름
+@Builder
+@Getter
+@Setter
+@RequiredArgsConstructor
+@AllArgsConstructor
+public class Personality {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY) // 자동 증가
+    @Column(name = "personality_id", nullable = false, unique = true)
+    private Long personalityId;
+
+    @Column(name = "content", nullable = false, unique = true)
+    private String content;
+}

--- a/src/main/java/com/cmyk/ego/speaktoyouspring/api/hub/personality/PersonalityController.java
+++ b/src/main/java/com/cmyk/ego/speaktoyouspring/api/hub/personality/PersonalityController.java
@@ -41,7 +41,7 @@ public class PersonalityController {
     @Operation(summary = "성격 추가 API")
     @PostMapping("/")
     public ResponseEntity add(@RequestBody ContentRequest contentRequest) {
-        var result = personalityService.add(contentRequest);
+        var result = personalityService.add(contentRequest.getContent());
         return ResponseEntity.ok(CommonResponse.builder().code(200).message("성격 추가 완료").data(result).build());
     }
 

--- a/src/main/java/com/cmyk/ego/speaktoyouspring/api/hub/personality/PersonalityController.java
+++ b/src/main/java/com/cmyk/ego/speaktoyouspring/api/hub/personality/PersonalityController.java
@@ -27,7 +27,7 @@ public class PersonalityController {
     /**
      * 성격 전체 조회
      */
-    @Operation(summary = "성격 전체 조회 API")
+    @Operation(summary = "성격 전체 조회 API", description = "테이블 내 모든 성격을 확인할 수 있습니다.")
     @GetMapping("/all")
     public ResponseEntity findAll() {
         var result = personalityService.findAll();
@@ -38,8 +38,8 @@ public class PersonalityController {
     /**
      * 성격 추가
      */
-    @Operation(summary = "성격 추가 API")
-    @PostMapping("/")
+    @Operation(summary = "성격 추가 API", description = "해당하는 성격이 기존 테이블에 있다면, 중복되게 추가되지 않고, \n url을 변경하면 해당 성격의 URL이 업데이트 됩니다.")
+    @PostMapping("")
     public ResponseEntity add(@RequestBody ContentRequest contentRequest) {
         var result = personalityService.add(contentRequest.getContent());
         return ResponseEntity.ok(CommonResponse.builder().code(200).message("성격 추가 완료").data(result).build());
@@ -48,7 +48,7 @@ public class PersonalityController {
     /**
      * 성격 리스트 추가
      */
-    @Operation(summary = "성격 리스트 추가 API")
+    @Operation(summary = "성격 리스트 추가 API", description = "해당하는 성격이 기존 테이블에 있다면, 중복되게 추가되지 않고, \n url을 변경하면 해당 성격의 URL이 업데이트 됩니다.")
     @PostMapping("/list")
     public ResponseEntity addList(@RequestBody ContentListRequest contentListRequest) {
         var result = personalityService.addList(contentListRequest);
@@ -58,8 +58,8 @@ public class PersonalityController {
     /**
      * 성격 전체 삭제
      */
-    @Operation(summary = "성격 전체 삭제 API *테스트용으로도 실행을 권장하지 않음*")
-    @DeleteMapping("/")
+    @Operation(summary = "성격 전체 삭제 API *테스트용으로도 실행을 권장하지 않음*", description = "성격 테이블에 모든 정보가 완전 삭제되기 때문에 에고 성격과 연동해놓았다면, \n 에고 정보를 조회할때 오류가 날 수 있습니다. \n 이 경우, 에고 테이블에서 수정 API를 추가로 호출하셔야 합니다.")
+    @DeleteMapping("")
     public ResponseEntity deleteAll() {
         personalityService.deleteAll();
         return ResponseEntity.ok(CommonResponse.builder().code(200).message("성격 전체 삭제 완료").build());

--- a/src/main/java/com/cmyk/ego/speaktoyouspring/api/hub/personality/PersonalityController.java
+++ b/src/main/java/com/cmyk/ego/speaktoyouspring/api/hub/personality/PersonalityController.java
@@ -58,7 +58,7 @@ public class PersonalityController {
     /**
      * 성격 전체 삭제
      */
-    @Operation(summary = "성격 전체 삭제 API")
+    @Operation(summary = "성격 전체 삭제 API *테스트용으로도 실행을 권장하지 않음*")
     @DeleteMapping("/")
     public ResponseEntity deleteAll() {
         personalityService.deleteAll();

--- a/src/main/java/com/cmyk/ego/speaktoyouspring/api/hub/personality/PersonalityController.java
+++ b/src/main/java/com/cmyk/ego/speaktoyouspring/api/hub/personality/PersonalityController.java
@@ -1,0 +1,67 @@
+package com.cmyk.ego.speaktoyouspring.api.hub.personality;
+
+import com.cmyk.ego.speaktoyouspring.config.CommonResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/v1/personality")
+@RequiredArgsConstructor
+@Validated
+public class PersonalityController {
+    private final PersonalityService personalityService;
+
+    /**
+     * personality_id로 특정 성격 조회
+     */
+    @Operation(summary = "특정 성격 조회 API")
+    @GetMapping("/{personalityId}")
+    public ResponseEntity findById(@PathVariable Long personalityId) {
+        var result = personalityService.findByPersonalityId(personalityId);
+        return ResponseEntity.ok(CommonResponse.builder().code(200).message("특정 personality 조회 완료").data(result).build());
+    }
+
+    /**
+     * 성격 전체 조회
+     */
+    @Operation(summary = "성격 전체 조회 API")
+    @GetMapping("/all")
+    public ResponseEntity findAll() {
+        var result = personalityService.findAll();
+        return ResponseEntity.ok(CommonResponse.builder().code(200).message("personality 전체 조회 완료").data(result).build());
+    }
+
+
+    /**
+     * 성격 추가
+     */
+    @Operation(summary = "성격 추가 API")
+    @PostMapping("/")
+    public ResponseEntity add(@RequestBody ContentRequest contentRequest) {
+        var result = personalityService.add(contentRequest);
+        return ResponseEntity.ok(CommonResponse.builder().code(200).message("성격 추가 완료").data(result).build());
+    }
+
+    /**
+     * 성격 리스트 추가
+     */
+    @Operation(summary = "성격 리스트 추가 API")
+    @PostMapping("/list")
+    public ResponseEntity addList(@RequestBody ContentListRequest contentListRequest) {
+        var result = personalityService.addList(contentListRequest);
+        return ResponseEntity.ok(CommonResponse.builder().code(200).message("성격 리스트 추가 완료").data(result).build());
+    }
+
+    /**
+     * 성격 전체 삭제
+     */
+    @Operation(summary = "성격 전체 삭제 API")
+    @DeleteMapping("/")
+    public ResponseEntity deleteAll() {
+        personalityService.deleteAll();
+        return ResponseEntity.ok(CommonResponse.builder().code(200).message("성격 전체 삭제 완료").build());
+    }
+}

--- a/src/main/java/com/cmyk/ego/speaktoyouspring/api/hub/personality/PersonalityRepository.java
+++ b/src/main/java/com/cmyk/ego/speaktoyouspring/api/hub/personality/PersonalityRepository.java
@@ -1,0 +1,11 @@
+package com.cmyk.ego.speaktoyouspring.api.hub.personality;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface PersonalityRepository extends JpaRepository<Personality, Long> {
+    Optional<Personality> findByPersonalityId(Long personalityId);
+
+    Optional<Personality> findByContent(String content);
+}

--- a/src/main/java/com/cmyk/ego/speaktoyouspring/api/hub/personality/PersonalityService.java
+++ b/src/main/java/com/cmyk/ego/speaktoyouspring/api/hub/personality/PersonalityService.java
@@ -1,0 +1,56 @@
+package com.cmyk.ego.speaktoyouspring.api.hub.personality;
+
+import com.cmyk.ego.speaktoyouspring.exception.ControlledException;
+import com.cmyk.ego.speaktoyouspring.exception.errorcode.PersonalityErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.bind.annotation.PathVariable;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class PersonalityService {
+    private final PersonalityRepository personalityRepository;
+
+    /// personality_id로 특정 성격 조회
+    public Personality findByPersonalityId(@PathVariable Long personalityId) {
+        return personalityRepository.findByPersonalityId(personalityId).orElseThrow(
+                () -> new ControlledException(PersonalityErrorCode.ERROR_PERSONALITY_ID_NOT_FOUND)
+        );
+    }
+
+    /// 성격 전체 조회
+    public List<Personality> findAll() {
+        return personalityRepository.findAll();
+    }
+
+    /// 성격 추가
+    public Personality add(ContentRequest contentRequest) {
+        String content = contentRequest.getContent();
+        return personalityRepository
+                .findByContent(content)
+                .orElseGet(() -> personalityRepository.save(new Personality(null, content)));
+    }
+
+    /// 성격 리스트 추가
+    public List<String> addList(ContentListRequest contentListRequest) {
+        List<String> newPersonalityList = new ArrayList<>();
+        // 새로 생성
+        for (String content : contentListRequest.getContentList()) {
+            Personality personality = add(new ContentRequest(content));
+            newPersonalityList.add(personality.getContent());
+        }
+        return newPersonalityList;
+    }
+
+    /// 성격 전체 삭제
+    public void deleteAll() {
+        personalityRepository.deleteAll();
+    }
+
+
+}

--- a/src/main/java/com/cmyk/ego/speaktoyouspring/api/hub/personality/PersonalityService.java
+++ b/src/main/java/com/cmyk/ego/speaktoyouspring/api/hub/personality/PersonalityService.java
@@ -29,8 +29,7 @@ public class PersonalityService {
     }
 
     /// 성격 추가
-    public Personality add(ContentRequest contentRequest) {
-        String content = contentRequest.getContent();
+    public Personality add(String content) {
         return personalityRepository
                 .findByContent(content)
                 .orElseGet(() -> personalityRepository.save(new Personality(null, content)));
@@ -41,7 +40,7 @@ public class PersonalityService {
         List<String> newPersonalityList = new ArrayList<>();
         // 새로 생성
         for (String content : contentListRequest.getContentList()) {
-            Personality personality = add(new ContentRequest(content));
+            Personality personality = add(content);
             newPersonalityList.add(personality.getContent());
         }
         return newPersonalityList;

--- a/src/main/java/com/cmyk/ego/speaktoyouspring/api/hub/personality/PersonalityService.java
+++ b/src/main/java/com/cmyk/ego/speaktoyouspring/api/hub/personality/PersonalityService.java
@@ -9,6 +9,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 @Service
 @Transactional
@@ -32,16 +33,35 @@ public class PersonalityService {
     public Personality add(String content) {
         return personalityRepository
                 .findByContent(content)
-                .orElseGet(() -> personalityRepository.save(new Personality(null, content)));
+                .orElseGet(() -> personalityRepository.save(new Personality(null, content, null)));
+    }
+
+    /// 성격 추가
+    public Personality add(ContentRequest content) {
+        Personality existing = personalityRepository.findByContent(content.getContent()).orElse(null);
+
+        if (existing != null) {
+            // imageUrl이 다르면 업데이트
+            if (!Objects.equals(existing.getImageUrl(), content.getImageUrl())) {
+                existing.setImageUrl(content.getImageUrl());
+                return personalityRepository.save(existing); // 변경 저장
+            }
+            return existing; // 동일하면 그대로 반환
+        }
+
+        // 없으면 새로 저장
+        return personalityRepository.save(
+                new Personality(null, content.getContent(), content.getImageUrl())
+        );
     }
 
     /// 성격 리스트 추가
-    public List<String> addList(ContentListRequest contentListRequest) {
-        List<String> newPersonalityList = new ArrayList<>();
+    public List<Personality> addList(ContentListRequest contentListRequest) {
+        List<Personality> newPersonalityList = new ArrayList<>();
         // 새로 생성
-        for (String content : contentListRequest.getContentList()) {
+        for (ContentRequest content : contentListRequest.getContentList()) {
             Personality personality = add(content);
-            newPersonalityList.add(personality.getContent());
+            newPersonalityList.add(personality);
         }
         return newPersonalityList;
     }

--- a/src/main/java/com/cmyk/ego/speaktoyouspring/api/personalized_data/egolike/EgoLikeController.java
+++ b/src/main/java/com/cmyk/ego/speaktoyouspring/api/personalized_data/egolike/EgoLikeController.java
@@ -23,7 +23,7 @@ public class EgoLikeController {
     /**
      * ego 좋아요 등록
      */
-    @PostMapping("/")
+    @PostMapping("")
     public ResponseEntity update(@RequestBody EgoLikeDTO egoLikeDTO) {
 
         // 전달받은 Uid가 있는지 확인

--- a/src/main/java/com/cmyk/ego/speaktoyouspring/exception/errorcode/PersonalityErrorCode.java
+++ b/src/main/java/com/cmyk/ego/speaktoyouspring/exception/errorcode/PersonalityErrorCode.java
@@ -1,0 +1,8 @@
+package com.cmyk.ego.speaktoyouspring.exception.errorcode;
+
+import com.cmyk.ego.speaktoyouspring.exception.ErrorMessage;
+
+public interface PersonalityErrorCode {
+    ErrorMessage ERROR_PERSONALITY_ID_NOT_FOUND = new ErrorMessage(404, "성격 ID 정보가 존재하지 않습니다.");
+    ErrorMessage ERROR_PERSONALITY_CONTENT_NOT_FOUND = new ErrorMessage(404, "성격 내용 정보가 존재하지 않습니다.");
+}

--- a/src/main/resources/db/migration/hub/V4.0__create_ego_personality.sql
+++ b/src/main/resources/db/migration/hub/V4.0__create_ego_personality.sql
@@ -1,0 +1,6 @@
+-- 에고와 에고 성격(여러 개)를 매핑 시켜놓은 테이블
+CREATE TABLE IF NOT EXISTS ego_personality (
+    ego_personality_id SERIAL PRIMARY KEY,                            -- 고유 ID (자동 증가)
+    ego_id INTEGER,                                                   -- ego의 ID
+    personality_id INTEGER                                           -- 성격 정보가 들어있는 테이블의 ID
+);

--- a/src/main/resources/db/migration/hub/V4.1__create_personality.sql
+++ b/src/main/resources/db/migration/hub/V4.1__create_personality.sql
@@ -1,0 +1,5 @@
+-- 에고의 성격을 나열해놓은 테이블
+CREATE TABLE IF NOT EXISTS ego_personality (
+    personality_id SERIAL PRIMARY KEY,                            -- 고유 ID (자동 증가)
+    conent VARCHAR(20)                                                   -- 성격 내용
+);

--- a/src/main/resources/db/migration/hub/V4.2__create_personality.sql
+++ b/src/main/resources/db/migration/hub/V4.2__create_personality.sql
@@ -1,0 +1,5 @@
+-- 에고의 성격을 나열해놓은 테이블
+CREATE TABLE IF NOT EXISTS personality (
+    personality_id SERIAL PRIMARY KEY,                            -- 고유 ID (자동 증가)
+    conent VARCHAR(20)                                                   -- 성격 내용
+);

--- a/src/main/resources/db/migration/hub/V4.3__drop_ego.sql
+++ b/src/main/resources/db/migration/hub/V4.3__drop_ego.sql
@@ -1,0 +1,1 @@
+ALTER TABLE ego DROP COLUMN personality;

--- a/src/main/resources/db/migration/hub/V4.4__alter_ego.sql
+++ b/src/main/resources/db/migration/hub/V4.4__alter_ego.sql
@@ -1,0 +1,5 @@
+ALTER TABLE ego
+DROP COLUMN profile_image;
+
+ALTER TABLE ego
+ADD COLUMN profile_image bytea;

--- a/src/main/resources/db/migration/hub/V4.5__alter_personality.sql
+++ b/src/main/resources/db/migration/hub/V4.5__alter_personality.sql
@@ -1,0 +1,2 @@
+ALTER TABLE personality
+ADD COLUMN image_url VARCHAR(255);


### PR DESCRIPTION
### JIRA Task 🔖
**Ticket**: [CMYK-184](https://hansung-capstone-cmyk.atlassian.net/browse/CMYK-184)
- **Branch** : feat/CMYK-184

### 작업 내용 📌
####  에고 성격 페이지 API
- 에고의 성격을 여러 개 가질 수 있게 했습니다.
- 에고 생성시 문자열 리스트로 추가하면 자동으로 추가가 됩니다.
- 개별적으로 조회/추가도 가능합니다.
- 성격별로 이미지(그룹 채팅용)도 추가가 가능합니다.

### 참고 사항 📂
- 그룹 채팅을 고려해서 만들다가 채팅 데이터가 Firebase에서 이루어지는 것을 감안해 채팅 부분을 보류하고 다른 API으로 넘어가겠습니다.
- 채팅 관련된 부분은 토-점심 이후에 가장 높은 순서로 작업 예정입니다. (파베 관련 작업 포함)
- API 내용은 BE 작업이 마무리 되면, API 문서를 만들 생각입니다.

[CMYK-184]: https://hansung-capstone-cmyk.atlassian.net/browse/CMYK-184?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ