### PR TITLE
[CMYK-220]: 캘린더 월 감정 API

### DIFF
--- a/src/main/java/com/cmyk/ego/speaktoyouspring/api/personalized_data/calendar/CalendarApplicationSerivce.java
+++ b/src/main/java/com/cmyk/ego/speaktoyouspring/api/personalized_data/calendar/CalendarApplicationSerivce.java
@@ -1,0 +1,36 @@
+package com.cmyk.ego.speaktoyouspring.api.personalized_data.calendar;
+
+import com.cmyk.ego.speaktoyouspring.api.hub.user_account.UserAccountRepository;
+import com.cmyk.ego.speaktoyouspring.api.personalized_data.diary.Diary;
+import com.cmyk.ego.speaktoyouspring.api.personalized_data.diary.DiaryService;
+import com.cmyk.ego.speaktoyouspring.config.multitenancy.TenantContext;
+import com.cmyk.ego.speaktoyouspring.exception.ControlledException;
+import com.cmyk.ego.speaktoyouspring.exception.errorcode.UserAccountErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class CalendarApplicationSerivce {
+    private final DiaryService diaryService;
+    private final UserAccountRepository userAccountRepository;
+
+    /**
+     * user_id로 월별 일기 리스트 조회하는 API
+     */
+    public List<List<CalendarDTO>> findByMonth(String uid, int month, int year) {
+        // 전달받은 Uid가 있는지 확인
+        userAccountRepository.findByUid(uid).orElseThrow(
+                () -> new ControlledException(UserAccountErrorCode.ERROR_USER_NOT_FOUND));
+        TenantContext.setCurrentTenant(uid);
+
+        List<Diary> diaries = diaryService.findByUserIdAndCreatedAt(uid, LocalDate.of(year, month, 1));
+
+        return CalendarService.findByMonth(diaries);
+    }
+}

--- a/src/main/java/com/cmyk/ego/speaktoyouspring/api/personalized_data/calendar/CalendarController.java
+++ b/src/main/java/com/cmyk/ego/speaktoyouspring/api/personalized_data/calendar/CalendarController.java
@@ -1,0 +1,32 @@
+package com.cmyk.ego.speaktoyouspring.api.personalized_data.calendar;
+
+import com.cmyk.ego.speaktoyouspring.config.CommonResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/v1/calendar")
+@RequiredArgsConstructor
+@Validated
+public class CalendarController {
+    private final CalendarApplicationSerivce calendarApplicationSerivce;
+    /**
+     * user_id로 월별 일기 리스트 조회하는 API
+     */
+    @Operation(summary = "월별 캘린더 리스트 조회 API", description = "user_id로 월별 일기 리스트를 조회하는 API, 년(YYYY), 월(M)을 쿼리스트링으로 추가할 수 있고 해당 년월에 앞뒤 1개월까지 리스트로 반환한다.<br><br>" +
+            "각 path의 값의 도메인은 다음과 같다."+
+            "<li>행복: assets/icon/emotion/happiness.svg</li><br>" +
+            "<li>평범: assets/icon/emotion/embarrassment.svg</li><br>" +
+            "<li>불안: assets/icon/emotion/disappointment.svg</li><br>" +
+            "<li>화남: assets/icon/emotion/anger.svg</li><br>" +
+            "<li>슬픔: assets/icon/emotion/sadness.svg</li>")
+    @GetMapping("/{userId}")
+    public ResponseEntity findByMonth(@PathVariable String userId, @RequestParam(defaultValue = "5") int month, @RequestParam(defaultValue = "2025") int year) {
+
+        var result = calendarApplicationSerivce.findByMonth(userId, month, year);
+        return ResponseEntity.ok(CommonResponse.builder().code(200).message("월별 캘린더 조회 완료").data(result).build());
+    }
+}

--- a/src/main/java/com/cmyk/ego/speaktoyouspring/api/personalized_data/calendar/CalendarDTO.java
+++ b/src/main/java/com/cmyk/ego/speaktoyouspring/api/personalized_data/calendar/CalendarDTO.java
@@ -1,0 +1,22 @@
+package com.cmyk.ego.speaktoyouspring.api.personalized_data.calendar;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import lombok.*;
+
+import java.time.LocalDate;
+import java.util.Date;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class CalendarDTO {
+
+    private Long id;                      // diray_id
+
+    private LocalDate createdAt;             // EGO 프로필 이미지
+
+    private String path;                     // MBTI 성격 유형
+}

--- a/src/main/java/com/cmyk/ego/speaktoyouspring/api/personalized_data/calendar/CalendarService.java
+++ b/src/main/java/com/cmyk/ego/speaktoyouspring/api/personalized_data/calendar/CalendarService.java
@@ -1,0 +1,42 @@
+package com.cmyk.ego.speaktoyouspring.api.personalized_data.calendar;
+
+import com.cmyk.ego.speaktoyouspring.api.personalized_data.diary.Diary;
+import com.cmyk.ego.speaktoyouspring.api.personalized_data.diary.EmotionIconMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.YearMonth;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+import java.util.stream.Collectors;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class CalendarService {
+    /**
+     * user_id로 월별 일기 리스트 조회하는 API
+     */
+    public static List<List<CalendarDTO>> findByMonth(List<Diary> diaries) {
+
+        // 1. 먼저 CalendarDTO로 변환 + 연월 그룹화
+        Map<YearMonth, List<CalendarDTO>> groupedByYearMonth = diaries.stream()
+                .map(diary -> new CalendarDTO(
+                        diary.getDiaryId(),
+                        diary.getCreatedAt(),
+                        EmotionIconMapper.getFirstIconFromText(diary.getFeeling().isEmpty() ? "평범" : diary.getFeeling())
+                                .orElse(EmotionIconMapper.getDefaultIcon()) // "평범" 대체 메서드 사용
+                ))
+                .collect(Collectors.groupingBy(
+                        dto -> YearMonth.from(dto.getCreatedAt()),
+                        TreeMap::new, // 정렬된 Map
+                        Collectors.toList()
+                ));
+
+        // 2. Map의 값들만 꺼내면 원하는 결과 타입
+       return new ArrayList<>(groupedByYearMonth.values());
+    }
+}

--- a/src/main/java/com/cmyk/ego/speaktoyouspring/api/personalized_data/diary/DiaryDTO.java
+++ b/src/main/java/com/cmyk/ego/speaktoyouspring/api/personalized_data/diary/DiaryDTO.java
@@ -50,6 +50,7 @@ public class DiaryDTO {
                 .uid(uid)
                 .egoId(egoId)
                 .createdAt(createdAt)
+                .feeling(feeling)
                 .dailyComment(dailyComment)
                 .build();
     }

--- a/src/main/java/com/cmyk/ego/speaktoyouspring/api/personalized_data/diary/DiaryRepository.java
+++ b/src/main/java/com/cmyk/ego/speaktoyouspring/api/personalized_data/diary/DiaryRepository.java
@@ -3,9 +3,11 @@ package com.cmyk.ego.speaktoyouspring.api.personalized_data.diary;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.time.LocalDate;
+import java.util.List;
 import java.util.Optional;
 
 public interface DiaryRepository extends JpaRepository<Diary, Long> {
     Diary findByEgoIdAndCreatedAt(Long egoId, LocalDate createdAt);
     Optional<Diary> findByDiaryId(Long diaryId);
+    List<Diary> findByCreatedAtBetween(LocalDate start, LocalDate end);
 }

--- a/src/main/java/com/cmyk/ego/speaktoyouspring/api/personalized_data/diary/DiaryService.java
+++ b/src/main/java/com/cmyk/ego/speaktoyouspring/api/personalized_data/diary/DiaryService.java
@@ -1,16 +1,23 @@
 package com.cmyk.ego.speaktoyouspring.api.personalized_data.diary;
 
+import com.cmyk.ego.speaktoyouspring.api.hub.user_account.UserAccountRepository;
+import com.cmyk.ego.speaktoyouspring.config.multitenancy.TenantContext;
 import com.cmyk.ego.speaktoyouspring.exception.ControlledException;
 import com.cmyk.ego.speaktoyouspring.exception.errorcode.DiaryErrorCode;
+import com.cmyk.ego.speaktoyouspring.exception.errorcode.UserAccountErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.List;
 
 @Service
 @Transactional
 @RequiredArgsConstructor
 public class DiaryService {
     private final DiaryRepository diaryRepository;
+    private final UserAccountRepository userAccountRepository;
 
     public Diary upsert(DiaryDTO diaryDTO){
         Diary diary = diaryRepository.findByEgoIdAndCreatedAt(diaryDTO.getEgoId(), diaryDTO.getCreatedAt());
@@ -29,5 +36,26 @@ public class DiaryService {
         return diaryRepository.findByDiaryId(diaryId).orElseThrow(
                 () -> new ControlledException(DiaryErrorCode.ERROR_DIARY_NOT_FOUND)
         );
+    }
+
+    /// userId와 createdAt으로 diary 리스트 조회
+    public List<Diary> findByUserIdAndCreatedAt(String uid, LocalDate currentMonth){
+        // 전달받은 Uid가 있는지 확인
+        userAccountRepository.findByUid(uid).orElseThrow(
+                () -> new ControlledException(UserAccountErrorCode.ERROR_USER_NOT_FOUND));
+        TenantContext.setCurrentTenant(uid);
+
+        // 현재 월을 기준으로 앞뒤 가져올 월 개수 설정
+        int range = 1;
+
+        // 최초 달의 시작 날
+        LocalDate prevMonth = currentMonth.minusMonths(range);
+
+        // 마지막 달의 끝 날
+        LocalDate nextMonth = currentMonth.plusMonths(1).withDayOfMonth(
+                currentMonth.plusMonths(1).lengthOfMonth()
+        );
+
+        return diaryRepository.findByCreatedAtBetween(prevMonth, nextMonth);
     }
 }

--- a/src/main/java/com/cmyk/ego/speaktoyouspring/api/personalized_data/diary/EmotionIconMapper.java
+++ b/src/main/java/com/cmyk/ego/speaktoyouspring/api/personalized_data/diary/EmotionIconMapper.java
@@ -1,0 +1,31 @@
+package com.cmyk.ego.speaktoyouspring.api.personalized_data.diary;
+
+import java.util.Arrays;
+import java.util.Map;
+import java.util.Optional;
+
+public class EmotionIconMapper {
+    public static final Map<String, String> emotionIconMap = Map.of(
+            "행복", "assets/icon/emotion/happiness.svg",
+            "평범", "assets/icon/emotion/embarrassment.svg",
+            "불안", "assets/icon/emotion/disappointment.svg",
+            "화남", "assets/icon/emotion/anger.svg",
+            "슬픔", "assets/icon/emotion/sadness.svg"
+    );
+
+    public static String getDefaultIcon() {
+        return emotionIconMap.get("평범");
+    }
+
+    // 문자열에서 첫 단어를 찾아 매핑된 아이콘 반환
+    public static Optional<String> getFirstIconFromText(String emotionText) {
+        return Arrays.stream(emotionText.split(","))
+                .map(String::trim)
+                .findFirst()
+                .flatMap(emotion -> emotionIconMap.containsKey(emotion)
+                        ? Optional.of(emotionIconMap.get(emotion))
+                        : Optional.empty()
+                );
+    }
+}
+


### PR DESCRIPTION
### JIRA Task 🔖
**Ticket**: [CMYK-220](https://hansung-capstone-cmyk.atlassian.net/browse/CMYK-220)
- **Branch** : feat/CMYK-220

### 작업 내용 📌
####  캘린더 월 감정 API
- 사용자 ID와 쿼리스트링으로 이전 월/해당 월/다음 월의 정보를 가져올 수 있는 API
- 일기ID, 날짜, 감정아이콘경로를 월별 배열로 묶어서 배열 in 배열 구조로 리턴

### 참고 사항 📂
- 감정 중 평범은 매핑 이미지 이름이 이상해서 embarrassment로 매핑했습니다. (바꾸려면 BE 코드 수정해야 하니 연락 주세요)
- API 내용은 BE 작업이 마무리 되면, API 문서를 만들 생각입니다.

[CMYK-220]: https://hansung-capstone-cmyk.atlassian.net/browse/CMYK-220?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ