### PR TITLE
[CMYK-218]: 실시간 채팅 Firebase 설정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -70,7 +70,7 @@ dependencies {
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
     // for Firebase
-    implementation 'com.google.firebase:firebase-admin:9.2.0'
+    implementation 'com.google.firebase:firebase-admin:9.4.3'
 
     //for Spring Security
     implementation 'org.springframework.boot:spring-boot-starter-security'

--- a/src/main/java/com/cmyk/ego/speaktoyouspring/api/personalized_data/chathistory/ChatHistoryController.java
+++ b/src/main/java/com/cmyk/ego/speaktoyouspring/api/personalized_data/chathistory/ChatHistoryController.java
@@ -5,12 +5,6 @@ import com.cmyk.ego.speaktoyouspring.config.CommonResponse;
 import com.cmyk.ego.speaktoyouspring.config.multitenancy.TenantContext;
 import com.cmyk.ego.speaktoyouspring.exception.ControlledException;
 import com.cmyk.ego.speaktoyouspring.exception.errorcode.UserAccountErrorCode;
-import com.google.cloud.Timestamp;
-import com.google.cloud.firestore.CollectionReference;
-import com.google.cloud.firestore.Firestore;
-import com.google.cloud.firestore.Query;
-import com.google.cloud.firestore.QueryDocumentSnapshot;
-import com.google.firebase.cloud.FirestoreClient;
 import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -19,8 +13,6 @@ import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.*;
 
 import java.io.IOException;
-import java.text.SimpleDateFormat;
-import java.util.*;
 import java.util.concurrent.ExecutionException;
 import java.util.stream.Collectors;
 
@@ -178,71 +170,23 @@ public class ChatHistoryController {
     @GetMapping("/{uid}/{datetime}")
     public ResponseEntity getChatHistoriesByUid(@PathVariable(value = "uid") String userid, @PathVariable("datetime") String datetime) throws IOException, ExecutionException, InterruptedException {
 
-        // 작성을 원하는 ~ 날짜의 문자열을 Date 객체로 변환 (형식: yyyy-MM-dd)
-        Date targetDate = parseDate(datetime);
-        if (targetDate == null) {
+        // 전달받은 Uid가 있는지 확인
+        userAccountRepository.findByUid(userid).orElseThrow(
+                () -> new ControlledException(UserAccountErrorCode.ERROR_USER_NOT_FOUND));
+
+        TenantContext.setCurrentTenant(userid);
+
+        if (datetime == null) {
             return ResponseEntity.badRequest().body("유효하지 않은 일자 형식입니다. yyyy-MM-dd로 입력해주세요.");
         }
 
-        Firestore db = FirestoreClient.getFirestore();
-        List<Map<String, Object>> result = new ArrayList<>();
-
-        // chats/user_chat/ 하위 [컬렉션]들 조회 (ex. user1_user2, user3_user1 등)
-        for (CollectionReference chatCollection : db.collection("chats").document("user_chat").listCollections()) {
-            // 해당 컬렉션명이 요청한 사용자 ID를 포함하는 경우만 처리
-            if (!chatCollection.getId().contains(userid)) continue;
-
-            // 필드 중 timestamp를 기준으로 오름차순으로 채팅 메세지 [문서]들 정렬
-            List<QueryDocumentSnapshot> documents = chatCollection
-                    .orderBy("timestamp", Query.Direction.ASCENDING)
-                    .get().get().getDocuments();
-
-            // 채팅 메세지 [문서] 하나씩 순회하면서 요청한 날짜 필터링 및 결과 리스트에 추가
-            for (QueryDocumentSnapshot doc : documents) {
-                Timestamp timestamp = doc.getTimestamp("timestamp");
-
-                // timestamp가 없거나 날짜가 일치하지 않으면 skip
-                if (timestamp == null || !isSameDay(timestamp.toDate(), targetDate)) continue;
-
-                // 결과 리스트에 담을 필드만 추출하여 Map 생성
-                result.add(Map.of(
-                        "uid", Objects.requireNonNull(doc.getString("sender_id")), // 보낸 사람 UID
-                        "type", Objects.requireNonNull(doc.getString("sender_id")).equals(userid) ? "U" : "E",
-                        "content", Objects.requireNonNull(doc.getString("text")), // 채팅 내용
-                        "chat_at", formatDate(timestamp.toDate()) // 보낸 날짜 (yyyy-MM-dd)
-                ));
-            }
-        }
+        var result = chatHistoryService.getChatHistoryByChatRoomId(userid, datetime);
 
         return ResponseEntity.ok(CommonResponse.builder()
                 .code(200)
-                .message(String.format("%s일자의 채팅내역 조회", datetime))
+                .message(String.format("%s일 에고채팅, 사람채팅 내역 전체 조회", datetime))
                 .data(result)
                 .build());
-    }
-
-    // 날짜 파싱 (yyyy-MM-dd)
-    private Date parseDate(String dateStr) {
-        try {
-            return new SimpleDateFormat("yyyy-MM-dd", Locale.getDefault()).parse(dateStr);
-        } catch (Exception e) {
-            return null;
-        }
-    }
-
-    // Date → yyyy-MM-dd 문자열
-    private String formatDate(Date date) {
-        return new SimpleDateFormat("yyyy-MM-dd", Locale.getDefault()).format(date);
-    }
-
-    // 두 날짜가 같은 일인지 비교
-    private boolean isSameDay(Date d1, Date d2) {
-        Calendar c1 = Calendar.getInstance();
-        Calendar c2 = Calendar.getInstance();
-        c1.setTime(d1);
-        c2.setTime(d2);
-        return c1.get(Calendar.YEAR) == c2.get(Calendar.YEAR)
-                && c1.get(Calendar.DAY_OF_YEAR) == c2.get(Calendar.DAY_OF_YEAR);
     }
 
 }

--- a/src/main/java/com/cmyk/ego/speaktoyouspring/api/personalized_data/chathistory/ChatHistoryController.java
+++ b/src/main/java/com/cmyk/ego/speaktoyouspring/api/personalized_data/chathistory/ChatHistoryController.java
@@ -5,12 +5,23 @@ import com.cmyk.ego.speaktoyouspring.config.CommonResponse;
 import com.cmyk.ego.speaktoyouspring.config.multitenancy.TenantContext;
 import com.cmyk.ego.speaktoyouspring.exception.ControlledException;
 import com.cmyk.ego.speaktoyouspring.exception.errorcode.UserAccountErrorCode;
+import com.google.cloud.Timestamp;
+import com.google.cloud.firestore.CollectionReference;
+import com.google.cloud.firestore.Firestore;
+import com.google.cloud.firestore.Query;
+import com.google.cloud.firestore.QueryDocumentSnapshot;
+import com.google.firebase.cloud.FirestoreClient;
+import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.*;
 
+import java.io.IOException;
+import java.text.SimpleDateFormat;
+import java.util.*;
+import java.util.concurrent.ExecutionException;
 import java.util.stream.Collectors;
 
 @RestController
@@ -22,7 +33,7 @@ public class ChatHistoryController {
 
     /**
      * 채팅 내역 생성
-     * */
+     */
     @PostMapping
     public ResponseEntity create(@RequestBody @Valid ChatHistoryDTO chatHistoryDTO, BindingResult bindingResult) {
 
@@ -57,7 +68,7 @@ public class ChatHistoryController {
             @RequestParam(defaultValue = "0") int pageNum,
             @RequestParam(defaultValue = "10") int pageSize) {
 
-        if (pageNum<0 || pageSize<1) {
+        if (pageNum < 0 || pageSize < 1) {
             return ResponseEntity.badRequest()
                     .body(CommonResponse.builder()
                             .code(400)
@@ -87,7 +98,7 @@ public class ChatHistoryController {
     public ResponseEntity getUndeletedChatHistories(
             @RequestBody @Valid ChatHistoryRequest chatHistoryRequest,
             @RequestParam("date") String dateString,
-            BindingResult bindingResult){
+            BindingResult bindingResult) {
 
         if (bindingResult.hasErrors()) {
             String errorMessage = bindingResult.getFieldErrors().stream()
@@ -117,7 +128,7 @@ public class ChatHistoryController {
     /**
      * 채팅내역 삭제
      * 필수값 : uid, id
-     * */
+     */
     @DeleteMapping
     public ResponseEntity delete(@RequestBody ChatHistoryDTO chatHistoryDTO) {
 
@@ -161,6 +172,77 @@ public class ChatHistoryController {
         var result = chatHistoryService.deleteChatHistoryByHash(hash);
 
         return ResponseEntity.ok(CommonResponse.builder().code(200).message("대화 해시값으로 삭제 완료").data(result).build());
+    }
+
+    @Operation(summary = "유저의 채팅내역 조회", description = "uid와 날짜를 입력받아 해당 날짜의 채팅내역을 조회합니다. <br> example: uid: user_id_001 / user_id_002 <br> datetime: 2025-05-19")
+    @GetMapping("/{uid}/{datetime}")
+    public ResponseEntity getChatHistoriesByUid(@PathVariable(value = "uid") String userid, @PathVariable("datetime") String datetime) throws IOException, ExecutionException, InterruptedException {
+
+        // 작성을 원하는 ~ 날짜의 문자열을 Date 객체로 변환 (형식: yyyy-MM-dd)
+        Date targetDate = parseDate(datetime);
+        if (targetDate == null) {
+            return ResponseEntity.badRequest().body("유효하지 않은 일자 형식입니다. yyyy-MM-dd로 입력해주세요.");
+        }
+
+        Firestore db = FirestoreClient.getFirestore();
+        List<Map<String, Object>> result = new ArrayList<>();
+
+        // chats/user_chat/ 하위 [컬렉션]들 조회 (ex. user1_user2, user3_user1 등)
+        for (CollectionReference chatCollection : db.collection("chats").document("user_chat").listCollections()) {
+            // 해당 컬렉션명이 요청한 사용자 ID를 포함하는 경우만 처리
+            if (!chatCollection.getId().contains(userid)) continue;
+
+            // 필드 중 timestamp를 기준으로 오름차순으로 채팅 메세지 [문서]들 정렬
+            List<QueryDocumentSnapshot> documents = chatCollection
+                    .orderBy("timestamp", Query.Direction.ASCENDING)
+                    .get().get().getDocuments();
+
+            // 채팅 메세지 [문서] 하나씩 순회하면서 요청한 날짜 필터링 및 결과 리스트에 추가
+            for (QueryDocumentSnapshot doc : documents) {
+                Timestamp timestamp = doc.getTimestamp("timestamp");
+
+                // timestamp가 없거나 날짜가 일치하지 않으면 skip
+                if (timestamp == null || !isSameDay(timestamp.toDate(), targetDate)) continue;
+
+                // 결과 리스트에 담을 필드만 추출하여 Map 생성
+                result.add(Map.of(
+                        "uid", Objects.requireNonNull(doc.getString("sender_id")), // 보낸 사람 UID
+                        "type", Objects.requireNonNull(doc.getString("sender_id")).equals(userid) ? "U" : "E",
+                        "content", Objects.requireNonNull(doc.getString("text")), // 채팅 내용
+                        "chat_at", formatDate(timestamp.toDate()) // 보낸 날짜 (yyyy-MM-dd)
+                ));
+            }
+        }
+
+        return ResponseEntity.ok(CommonResponse.builder()
+                .code(200)
+                .message(String.format("%s일자의 채팅내역 조회", datetime))
+                .data(result)
+                .build());
+    }
+
+    // 날짜 파싱 (yyyy-MM-dd)
+    private Date parseDate(String dateStr) {
+        try {
+            return new SimpleDateFormat("yyyy-MM-dd", Locale.getDefault()).parse(dateStr);
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    // Date → yyyy-MM-dd 문자열
+    private String formatDate(Date date) {
+        return new SimpleDateFormat("yyyy-MM-dd", Locale.getDefault()).format(date);
+    }
+
+    // 두 날짜가 같은 일인지 비교
+    private boolean isSameDay(Date d1, Date d2) {
+        Calendar c1 = Calendar.getInstance();
+        Calendar c2 = Calendar.getInstance();
+        c1.setTime(d1);
+        c2.setTime(d2);
+        return c1.get(Calendar.YEAR) == c2.get(Calendar.YEAR)
+                && c1.get(Calendar.DAY_OF_YEAR) == c2.get(Calendar.DAY_OF_YEAR);
     }
 
 }

--- a/src/main/java/com/cmyk/ego/speaktoyouspring/api/personalized_data/chathistory/ChatHistoryController.java
+++ b/src/main/java/com/cmyk/ego/speaktoyouspring/api/personalized_data/chathistory/ChatHistoryController.java
@@ -180,7 +180,7 @@ public class ChatHistoryController {
             return ResponseEntity.badRequest().body("유효하지 않은 일자 형식입니다. yyyy-MM-dd로 입력해주세요.");
         }
 
-        var result = chatHistoryService.getChatHistoryByChatRoomId(userid, datetime);
+        var result = chatHistoryService.getChatHistoryByUidAndDate(userid, datetime);
 
         return ResponseEntity.ok(CommonResponse.builder()
                 .code(200)

--- a/src/main/java/com/cmyk/ego/speaktoyouspring/api/personalized_data/chathistory/ChatHistoryRepository.java
+++ b/src/main/java/com/cmyk/ego/speaktoyouspring/api/personalized_data/chathistory/ChatHistoryRepository.java
@@ -1,13 +1,13 @@
 package com.cmyk.ego.speaktoyouspring.api.personalized_data.chathistory;
 
-import java.util.List;
-import java.time.LocalDateTime;
-import java.util.Optional;
-
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
 
 
 @Repository
@@ -17,6 +17,9 @@ public interface ChatHistoryRepository extends JpaRepository<ChatHistory, Long> 
 
     // 채팅방 ID, 삭제 여부, 날짜를 기준으로 조회하는 메서드
     List<ChatHistory> findByChatRoomIdAndIsDeletedFalseAndChatAtBetween(Long chatRoomId, LocalDateTime start, LocalDateTime end);
+
+    // 날짜, 삭제 여부를 기준으로 조회하는 메서드
+    List<ChatHistory> findByChatAtBetweenAndIsDeletedFalse(LocalDateTime start, LocalDateTime end);
 
     // 삭제 처리되지 않은 hash 값을 가진 튜플 가져오기
     Optional<ChatHistory> findByMessageHashAndIsDeletedFalse(String messageHash);

--- a/src/main/java/com/cmyk/ego/speaktoyouspring/api/personalized_data/chathistory/ChatHistoryRepository.java
+++ b/src/main/java/com/cmyk/ego/speaktoyouspring/api/personalized_data/chathistory/ChatHistoryRepository.java
@@ -3,6 +3,7 @@ package com.cmyk.ego.speaktoyouspring.api.personalized_data.chathistory;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import java.time.LocalDateTime;
@@ -19,6 +20,7 @@ public interface ChatHistoryRepository extends JpaRepository<ChatHistory, Long> 
     List<ChatHistory> findByChatRoomIdAndIsDeletedFalseAndChatAtBetween(Long chatRoomId, LocalDateTime start, LocalDateTime end);
 
     // 날짜, 삭제 여부를 기준으로 조회하는 메서드
+    @Query("SELECT c FROM ChatHistory c WHERE c.chatAt BETWEEN :start AND :end AND c.isDeleted = false ORDER BY c.chatRoomId, c.chatAt")
     List<ChatHistory> findByChatAtBetweenAndIsDeletedFalse(LocalDateTime start, LocalDateTime end);
 
     // 삭제 처리되지 않은 hash 값을 가진 튜플 가져오기

--- a/src/main/java/com/cmyk/ego/speaktoyouspring/api/personalized_data/chathistory/ChatHistoryService.java
+++ b/src/main/java/com/cmyk/ego/speaktoyouspring/api/personalized_data/chathistory/ChatHistoryService.java
@@ -5,6 +5,12 @@ import com.cmyk.ego.speaktoyouspring.api.personalized_data.chatroom.ChatRoomRepo
 import com.cmyk.ego.speaktoyouspring.exception.ControlledException;
 import com.cmyk.ego.speaktoyouspring.exception.errorcode.ChatHistoryErrorCode;
 import com.cmyk.ego.speaktoyouspring.exception.errorcode.ChatRoomErrorCode;
+import com.google.cloud.Timestamp;
+import com.google.cloud.firestore.CollectionReference;
+import com.google.cloud.firestore.Firestore;
+import com.google.cloud.firestore.Query;
+import com.google.cloud.firestore.QueryDocumentSnapshot;
+import com.google.firebase.cloud.FirestoreClient;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -15,12 +21,12 @@ import org.springframework.stereotype.Service;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+import java.text.SimpleDateFormat;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
-import java.util.Comparator;
-import java.util.List;
-import java.util.Optional;
+import java.util.*;
+import java.util.concurrent.ExecutionException;
 
 @Service
 @RequiredArgsConstructor
@@ -83,6 +89,17 @@ public class ChatHistoryService {
      * 하루치 채팅 내역 조회
      * */
     public List<ChatHistory> getDailyChatHistories(Long chatRoomId, String dateString) {
+        List<LocalDateTime> dayList = convertStringToDayList(dateString);
+
+        List<ChatHistory> chatHistories = chatHistoryRepository.findByChatRoomIdAndIsDeletedFalseAndChatAtBetween(chatRoomId, dayList.getFirst(), dayList.getLast());
+
+        // 정렬 (오래된 순으로 정렬)
+        chatHistories.sort(Comparator.comparing(ChatHistory::getChatAt));
+
+        return chatHistories;
+    }
+
+    private List<LocalDateTime> convertStringToDayList(String dateString) {
         // 날짜 포맷 검증
         DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
         LocalDate date;
@@ -97,14 +114,8 @@ public class ChatHistoryService {
         LocalDateTime startOfDay = date.atStartOfDay();// 00:00:00
         LocalDateTime endOfDay = date.plusDays(1).atStartOfDay();// 다음날 00:00:00
 
-        List<ChatHistory> chatHistories = chatHistoryRepository.findByChatRoomIdAndIsDeletedFalseAndChatAtBetween(chatRoomId, startOfDay, endOfDay);
-
-        // 정렬 (오래된 순으로 정렬)
-        chatHistories.sort(Comparator.comparing(ChatHistory::getChatAt));
-
-        return chatHistories;
+        return Arrays.asList(startOfDay, endOfDay);
     }
-
 
     public ChatHistory deleteChatHistory(Long chatHistoryId){
         Optional<ChatHistory> chatHistoryOptional = chatHistoryRepository.findById(chatHistoryId);
@@ -151,5 +162,94 @@ public class ChatHistoryService {
             hexString.append(hex);
         }
         return hexString.toString();
+    }
+
+    ///
+    public List<List<Map<String, Object>>> getChatHistoryByChatRoomId(String userid, String datetime) {
+        List<List<Map<String, Object>>> list = new ArrayList<>();
+        List<Map<String, Object>> userChatList = getFirestoreChatHistory(userid, datetime);
+        list.add(userChatList);
+
+        List<LocalDateTime> dayList = convertStringToDayList(datetime);
+        List<Map<String, Object>> egoChatList = new ArrayList<>();
+        chatHistoryRepository.findByChatAtBetweenAndIsDeletedFalse(dayList.getFirst(), dayList.getLast()).forEach(chatHistory -> {
+            Map<String, Object> chatHistoryMap = Map.of(
+                    "uid", chatHistory.getUid(),
+                    "type", chatHistory.getType(),
+                    "content", chatHistory.getContent(),
+                    "chat_at", formatDate(java.sql.Timestamp.valueOf(chatHistory.getChatAt()))
+            );
+
+            egoChatList.add(chatHistoryMap);
+        });
+        list.add(egoChatList);
+
+        return list;
+    }
+
+    private List<Map<String, Object>> getFirestoreChatHistory(String userid, String datetime){
+
+        // 작성을 원하는 ~ 날짜의 문자열을 Date 객체로 변환 (형식: yyyy-MM-dd)
+        Date targetDate = parseDate(datetime);
+
+        Firestore db = FirestoreClient.getFirestore();
+        List<Map<String, Object>> result = new ArrayList<>();
+
+        // chats/user_chat/ 하위 [컬렉션]들 조회 (ex. user1_user2, user3_user1 등)
+        for (CollectionReference chatCollection : db.collection("chats").document("user_chat").listCollections()) {
+            // 해당 컬렉션명이 요청한 사용자 ID를 포함하는 경우만 처리
+            if (!chatCollection.getId().contains(userid)) continue;
+
+            try {
+                // 필드 중 timestamp를 기준으로 오름차순으로 채팅 메세지 [문서]들 정렬
+                List<QueryDocumentSnapshot> documents = chatCollection
+                        .orderBy("timestamp", Query.Direction.ASCENDING)
+                        .get().get().getDocuments();
+
+            // 채팅 메세지 [문서] 하나씩 순회하면서 요청한 날짜 필터링 및 결과 리스트에 추가
+            for (QueryDocumentSnapshot doc : documents) {
+                Timestamp timestamp = doc.getTimestamp("timestamp");
+
+                // timestamp가 없거나 날짜가 일치하지 않으면 skip
+                if (timestamp == null || !isSameDay(timestamp.toDate(), targetDate)) continue;
+
+                // 결과 리스트에 담을 필드만 추출하여 Map 생성
+                result.add(Map.of(
+                        "uid", Objects.requireNonNull(doc.getString("sender_id")), // 보낸 사람 UID
+                        "type", Objects.requireNonNull(doc.getString("sender_id")).equals(userid) ? "U" : "O",
+                        "content", Objects.requireNonNull(doc.getString("text")), // 채팅 내용
+                        "chat_at", formatDate(timestamp.toDate()) // 보낸 날짜 (yyyy-MM-dd)
+                ));
+            }
+            } catch (ExecutionException | InterruptedException e) {
+                e.printStackTrace();
+                throw new RuntimeException(e);
+            }
+        }
+        return result;
+    }
+
+    // 날짜 파싱 (yyyy-MM-dd)
+    private Date parseDate(String dateStr) {
+        try {
+            return new SimpleDateFormat("yyyy-MM-dd", Locale.getDefault()).parse(dateStr);
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    // Date → yyyy-MM-dd 문자열
+    private String formatDate(Date date) {
+        return new SimpleDateFormat("yyyy-MM-dd", Locale.getDefault()).format(date);
+    }
+
+    // 두 날짜가 같은 일인지 비교
+    private boolean isSameDay(Date d1, Date d2) {
+        Calendar c1 = Calendar.getInstance();
+        Calendar c2 = Calendar.getInstance();
+        c1.setTime(d1);
+        c2.setTime(d2);
+        return c1.get(Calendar.YEAR) == c2.get(Calendar.YEAR)
+                && c1.get(Calendar.DAY_OF_YEAR) == c2.get(Calendar.DAY_OF_YEAR);
     }
 }

--- a/src/main/java/com/cmyk/ego/speaktoyouspring/api/personalized_data/chathistory/ChatHistoryService.java
+++ b/src/main/java/com/cmyk/ego/speaktoyouspring/api/personalized_data/chathistory/ChatHistoryService.java
@@ -27,6 +27,7 @@ import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.*;
 import java.util.concurrent.ExecutionException;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -164,72 +165,94 @@ public class ChatHistoryService {
         return hexString.toString();
     }
 
-    ///
-    public List<List<Map<String, Object>>> getChatHistoryByChatRoomId(String userid, String datetime) {
-        List<List<Map<String, Object>>> list = new ArrayList<>();
+    // 사용자의 채팅 내역을 조회하여 날짜별로 그룹화된 결과를 반환
+    public List<List<Map<String, Object>>> getChatHistoryByUidAndDate(String userid, String datetime) {
+        List<List<Map<String, Object>>> result = new ArrayList<>();
+
+        // 1. Firestore에서 해당 유저의 채팅 내역 조회 (특정 날짜 기준)
         List<Map<String, Object>> userChatList = getFirestoreChatHistory(userid, datetime);
-        list.add(userChatList);
+        result.add(userChatList);
 
+        // 2. 날짜 범위 추출 (예: 하루의 시작~끝, 또는 다중 일자)
         List<LocalDateTime> dayList = convertStringToDayList(datetime);
-        List<Map<String, Object>> egoChatList = new ArrayList<>();
-        chatHistoryRepository.findByChatAtBetweenAndIsDeletedFalse(dayList.getFirst(), dayList.getLast()).forEach(chatHistory -> {
-            Map<String, Object> chatHistoryMap = Map.of(
-                    "uid", chatHistory.getUid(),
-                    "type", chatHistory.getType(),
-                    "content", chatHistory.getContent(),
-                    "chat_at", formatDate(java.sql.Timestamp.valueOf(chatHistory.getChatAt()))
-            );
 
-            egoChatList.add(chatHistoryMap);
-        });
-        list.add(egoChatList);
+        // 3. RDB에서 삭제되지 않은 전체 채팅 내역 조회 (날짜 범위 내)
+        List<ChatHistory> allChats = chatHistoryRepository.findByChatAtBetweenAndIsDeletedFalse(
+                dayList.getFirst(), dayList.getLast()
+        );
 
-        return list;
+        // 4. 채팅방 ID → 시간순으로 정렬
+        allChats.sort(
+                Comparator.comparing(ChatHistory::getChatRoomId)
+                        .thenComparing(ChatHistory::getChatAt)
+        );
+
+        // 5. 채팅방별로 그룹화
+        Map<Long, List<ChatHistory>> groupedByRoom = allChats.stream()
+                .collect(Collectors.groupingBy(ChatHistory::getChatRoomId));
+
+        // 6. 각 채팅방별로 사용자 채팅 내역을 리스트에 추가
+        for (List<ChatHistory> chatList : groupedByRoom.values()) {
+            List<Map<String, Object>> chatGroup = new ArrayList<>();
+
+            for (ChatHistory chat : chatList) {
+                chatGroup.add(Map.of(
+                        "uid", chat.getUid(),
+                        "type", chat.getType(),
+                        "content", chat.getContent(),
+                        "chat_at", formatDate(java.sql.Timestamp.valueOf(chat.getChatAt()))
+                ));
+            }
+
+            result.add(chatGroup);
+        }
+
+        return result;
     }
 
-    private List<Map<String, Object>> getFirestoreChatHistory(String userid, String datetime){
-
-        // 작성을 원하는 ~ 날짜의 문자열을 Date 객체로 변환 (형식: yyyy-MM-dd)
-        Date targetDate = parseDate(datetime);
-
-        Firestore db = FirestoreClient.getFirestore();
+    private List<Map<String, Object>> getFirestoreChatHistory(String userid, String datetime) {
         List<Map<String, Object>> result = new ArrayList<>();
+        Date targetDate = parseDate(datetime);
+        Firestore db = FirestoreClient.getFirestore();
 
-        // chats/user_chat/ 하위 [컬렉션]들 조회 (ex. user1_user2, user3_user1 등)
-        for (CollectionReference chatCollection : db.collection("chats").document("user_chat").listCollections()) {
-            // 해당 컬렉션명이 요청한 사용자 ID를 포함하는 경우만 처리
+        // chats/user_chat 하위의 모든 컬렉션(=채팅방) 탐색
+        for (CollectionReference chatCollection : db.collection("chats")
+                .document("user_chat")
+                .listCollections()) {
+            // 사용자의 ID를 포함하지 않는 컬렉션은 무시
             if (!chatCollection.getId().contains(userid)) continue;
 
             try {
-                // 필드 중 timestamp를 기준으로 오름차순으로 채팅 메세지 [문서]들 정렬
+                // 채팅 메시지를 timestamp 기준 오름차순 정렬
                 List<QueryDocumentSnapshot> documents = chatCollection
                         .orderBy("timestamp", Query.Direction.ASCENDING)
                         .get().get().getDocuments();
 
-            // 채팅 메세지 [문서] 하나씩 순회하면서 요청한 날짜 필터링 및 결과 리스트에 추가
-            for (QueryDocumentSnapshot doc : documents) {
-                Timestamp timestamp = doc.getTimestamp("timestamp");
+                for (QueryDocumentSnapshot doc : documents) {
+                    Timestamp timestamp = doc.getTimestamp("timestamp");
 
-                // timestamp가 없거나 날짜가 일치하지 않으면 skip
-                if (timestamp == null || !isSameDay(timestamp.toDate(), targetDate)) continue;
+                    // 유효하지 않거나 날짜가 다르면 건너뜀
+                    if (timestamp == null || !isSameDay(timestamp.toDate(), targetDate)) continue;
 
-                // 결과 리스트에 담을 필드만 추출하여 Map 생성
-                result.add(Map.of(
-                        "uid", Objects.requireNonNull(doc.getString("sender_id")), // 보낸 사람 UID
-                        "type", Objects.requireNonNull(doc.getString("sender_id")).equals(userid) ? "U" : "O",
-                        "content", Objects.requireNonNull(doc.getString("text")), // 채팅 내용
-                        "chat_at", formatDate(timestamp.toDate()) // 보낸 날짜 (yyyy-MM-dd)
-                ));
-            }
+                    // 필요한 필드만 추출하여 Map 형태로 저장
+                    result.add(Map.of(
+                            "uid", Objects.requireNonNull(doc.getString("sender_id")),
+                            "type", doc.getString("sender_id").equals(userid) ? "U" : "O",
+                            "content", Objects.requireNonNull(doc.getString("text")),
+                            "chat_at", formatDate(timestamp.toDate())
+                    ));
+                }
+
             } catch (ExecutionException | InterruptedException e) {
                 e.printStackTrace();
                 throw new RuntimeException(e);
             }
         }
+
         return result;
     }
 
-    // 날짜 파싱 (yyyy-MM-dd)
+    // yyyy-MM-dd 형식 문자열을 Date 객체로 변환
     private Date parseDate(String dateStr) {
         try {
             return new SimpleDateFormat("yyyy-MM-dd", Locale.getDefault()).parse(dateStr);
@@ -238,18 +261,18 @@ public class ChatHistoryService {
         }
     }
 
-    // Date → yyyy-MM-dd 문자열
+    // Date → yyyy-MM-dd 문자열로 포맷
     private String formatDate(Date date) {
         return new SimpleDateFormat("yyyy-MM-dd", Locale.getDefault()).format(date);
     }
 
-    // 두 날짜가 같은 일인지 비교
+    // 두 날짜가 같은 날인지 비교
     private boolean isSameDay(Date d1, Date d2) {
         Calendar c1 = Calendar.getInstance();
         Calendar c2 = Calendar.getInstance();
         c1.setTime(d1);
         c2.setTime(d2);
-        return c1.get(Calendar.YEAR) == c2.get(Calendar.YEAR)
-                && c1.get(Calendar.DAY_OF_YEAR) == c2.get(Calendar.DAY_OF_YEAR);
+        return c1.get(Calendar.YEAR) == c2.get(Calendar.YEAR) &&
+                c1.get(Calendar.DAY_OF_YEAR) == c2.get(Calendar.DAY_OF_YEAR);
     }
 }


### PR DESCRIPTION
### JIRA Task 🔖
**Ticket**: [CMYK-218](https://hansung-capstone-cmyk.atlassian.net/browse/CMYK-218)
- **Branch** : feat/CMYK-218

### 작업 내용 📌
####  실시간 채팅 Firebase 설정
- 실시간 대화는 FE <-> Firestore에서 작업을 진행합니다.
- 사용자 ID와 날짜(연-월-일)를 주면, 해당하는 에고와의 대화/사람과의 대화 내역이 채팅방 별로 기록을 전부 가져오는 방식입니다.
- 리턴 값은 uid/content/type/chat_at 입니다.

### 참고 사항 📂
- 파베에서 필터링하는 작업이 시간이 좀 걸립니다(0.5초) 성능 개선을 곧 할 예정입니다.
- DB 구조는 [Firestore 메세지 관리](https://hansung-capstone-cmyk.atlassian.net/wiki/pages/resumedraft.action?draftId=41091080)에서 확인할 수 있습니다.
- API 내용은 BE 작업이 마무리 되면, API 문서를 만들 생각입니다.